### PR TITLE
Add support for hwconf env variables and `fw_info` terminal command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,23 @@ RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
 include $(RULESPATH)/arm-none-eabi.mk
 include $(RULESPATH)/rules.mk
 
+SRC_SENTINEL := $(BUILDDIR)/hw_src
+HEADER_SENTINEL := $(BUILDDIR)/hw_header
+
+# Update the tracker files if HW_SRC or HW_HEADER has changed to trigger a rebuild
+ifeq ($(shell if [[ -d $(BUILDDIR) ]]; then printf 1; else printf ""; fi),1)
+  ifneq ($(file < $(SRC_SENTINEL)),$(HW_SRC))
+    $(info Updated $(SRC_SENTINEL))
+    $(file > $(SRC_SENTINEL),$(HW_SRC))
+    $(shell touch hwconf/hw.c conf_general.h)
+  endif
+  ifneq ($(file < $(HEADER_SENTINEL)),$(HW_HEADER))
+    $(info Updated $(HEADER_SENTINEL))
+    $(file > $(HEADER_SENTINEL),$(HW_HEADER))
+    $(shell touch hwconf/hw.h conf_general.h)
+  endif
+endif
+
 upload: build/$(PROJECT).bin
 	openocd -f stm32g4_stlinkv2.cfg \
 		-c "program build/$(PROJECT).elf verify reset exit"

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,43 @@
 # NOTE: Can be overridden externally.
 #
 
+ifndef GIT_COMMIT_HASH
+  GIT_COMMIT_HASH := $(shell git rev-parse --short HEAD)
+endif
+
+ifndef GIT_BRANCH_NAME
+  GIT_BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
+endif
+
+ifdef HW_SRC
+  ifndef HW_HEADER
+    $(error HW_HEADER not defined while HW_SRC was set, you must set both!)
+  endif
+  USE_CUSTOM_HW := 1
+endif
+ifdef HW_HEADER
+  ifndef HW_SRC
+    $(error HW_SRC not defined while HW_HEADER was set, you must set both!)
+  endif
+  USE_CUSTOM_HW := 1
+endif
+
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16 -D_GNU_SOURCE $(build_args)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16 -D_GNU_SOURCE
+  USE_OPT += -DGIT_COMMIT_HASH=\"$(GIT_COMMIT_HASH)\" -DGIT_BRANCH_NAME=\"$(GIT_BRANCH_NAME)\"
+  ifdef USER_GIT_COMMIT_HASH
+    USE_OPT += -DUSER_GIT_COMMIT_HASH=\"$(USER_GIT_COMMIT_HASH)\"
+  endif
+  ifdef USER_GIT_BRANCH_NAME
+    USE_OPT += -DUSER_GIT_BRANCH_NAME=\"$(USER_GIT_BRANCH_NAME)\"
+  endif
+  
+  ifneq ($(USE_CUSTOM_HW),)
+    USE_OPT += -DHW_SOURCE="\"$(HW_SRC)\"" -DHW_HEADER="\"$(HW_HEADER)\""
+  endif
+  
+  USE_OPT += $(build_args)
 endif
 
 # C specific options here (added to USE_OPT).

--- a/hwconf/hw.h
+++ b/hwconf/hw.h
@@ -22,7 +22,7 @@
 
 #include <math.h>
 
-#include "hw_lb_ant.h"
+#include HW_HEADER
 
 // Macros
 #ifndef LED_OFF

--- a/terminal.c
+++ b/terminal.c
@@ -50,6 +50,8 @@ static terminal_callback_struct callbacks[CALLBACK_LEN];
 static int callback_write = 0;
 
 void terminal_process_string(char *str) {
+	commands_printf("-> %s\n", str);
+	
 	enum { kMaxArgs = 64 };
 	int argc = 0;
 	char *argv[kMaxArgs];

--- a/terminal.c
+++ b/terminal.c
@@ -127,6 +127,17 @@ void terminal_process_string(char *str) {
 
 		commands_printf("Configuration flash write counter: %d", backup.conf_flash_write_cnt);
 		commands_printf(" ");
+	} else if (strcmp(argv[0], "fw_info") == 0) {
+		commands_printf("Git Branch: %s", GIT_BRANCH_NAME);
+		commands_printf("Git Hash  : %s", GIT_COMMIT_HASH);
+	
+#ifdef USER_GIT_BRANCH_NAME
+		commands_printf("User Git Branch: %s", USER_GIT_BRANCH_NAME);
+#endif
+#ifdef USER_GIT_COMMIT_HASH
+		commands_printf("User Git Hash  : %s", USER_GIT_COMMIT_HASH);
+#endif
+		commands_printf(" ");
 	} else if (strcmp(argv[0], "uptime") == 0) {
 		commands_printf("Uptime: %.2f s", (double)chVTGetSystemTimeX() / (double)CH_CFG_ST_FREQUENCY);
 	} else if (strcmp(argv[0], "adcs") == 0) {
@@ -160,6 +171,9 @@ void terminal_process_string(char *str) {
 
 		commands_printf("hw_status");
 		commands_printf("  Print some hardware status information.");
+		
+		commands_printf("fw_info");
+		commands_printf("  Print detailed firmware info.");
 
 		commands_printf("can_scan");
 		commands_printf("  Scan CAN-bus using ping commands, and print all devices that are found.");


### PR DESCRIPTION
Added support for supplying custom hw configuration files through environment variables `HW_SRC` and `HW_HEADER`, avoiding the need to modify the tree content.

Also added the `fw_info` command which prints the git commit details the firmware was built with. There is an option to specify user git commit details when building meant for projects with their own repo which use vesc_gpstm. These are then also printed by `fw_info`.

Additionally added a prompt to the terminal.

I've also opened similar PRs for the other VESC firmwares:
- https://github.com/vedderb/bldc/pull/772
- https://github.com/vedderb/vesc_bms_fw/pull/21
- https://github.com/vedderb/vesc_express/pull/44