### PR TITLE
Add support for `fw-info`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 
 ifndef GIT_COMMIT_HASH
-  GIT_COMMIT_HASH := $(shell git rev-parse --short HEAD)
+  GIT_COMMIT_HASH := $(shell git rev-parse HEAD)
 endif
 
 ifndef GIT_BRANCH_NAME

--- a/commands.c
+++ b/commands.c
@@ -335,6 +335,44 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 		}
 	} break;
 
+	case COMM_FW_INFO: {
+		// Write at most the first max_len characters of str into buffer,
+		// followed by a null byte.
+		void buffer_append_str_max_len(uint8_t *buffer, char *str, size_t max_len, int32_t *index) {
+			size_t str_len = strlen(str);
+			if (str_len > max_len) {
+				str_len = max_len;
+				return;
+			}
+			
+			memcpy(&buffer[*index], str, str_len);
+			*index += str_len;
+			buffer[(*index)++] = '\0';
+		}
+		
+		int32_t ind = 0;
+		uint8_t send_buffer[98];
+		
+		send_buffer[ind++] = COMM_FW_INFO;
+		
+		// This information is technically duplicated with COMM_FW_VERSION, but
+		// I don't care.
+		send_buffer[ind++] = FW_VERSION_MAJOR;
+		send_buffer[ind++] = FW_VERSION_MINOR;
+		send_buffer[ind++] = FW_TEST_VERSION_NUMBER;
+		
+		// We don't include the branch name unfortunately
+		buffer_append_str_max_len(send_buffer, GIT_COMMIT_HASH, 46, &ind);
+#ifdef USER_GIT_COMMIT_HASH
+		char *user_commit_hash = USER_GIT_COMMIT_HASH;
+#else
+		char *user_commit_hash = "";
+#endif
+		buffer_append_str_max_len(send_buffer, user_commit_hash, 46, &ind);
+
+		reply_func(send_buffer, ind);
+	} break;
+
 	// Blocking commands. Only one of them runs at any given time, in their
 	// own thread. If other blocking commands come before the previous one has
 	// finished, they are discarded.

--- a/datatypes.h
+++ b/datatypes.h
@@ -349,7 +349,18 @@ typedef enum {
 	COMM_SET_APPCONF_NO_STORE,
 	COMM_GET_GNSS,
 
-	COMM_LOG_DATA_F64,
+	COMM_LOG_DATA_F64						= 151,
+	
+	// COMM_LISP_RMSG						= 152,
+
+	//Placeholders for pinlock commands
+	// COMM_PINLOCK1						= 153,
+	// COMM_PINLOCK2						= 154,
+	// COMM_PINLOCK3						= 155,
+	
+	// COMM_SHUTDOWN						= 156,
+	
+	COMM_FW_INFO							= 157,
 } COMM_PACKET_ID;
 
 #endif /* DATATYPES_H_ */


### PR DESCRIPTION
This PR adds support for the new COMM_FW_INFO VESC command, used by the fw-info extension.

There are also three other PRs for all of the VESC firmware repos.
- https://github.com/vedderb/vesc_bms_fw/pull/22
- https://github.com/vedderb/vesc_express/pull/52
- https://github.com/vedderb/bldc/pull/791
